### PR TITLE
admin: Added an aggregating dashboard for admin user

### DIFF
--- a/app/controllers/hub_controller.rb
+++ b/app/controllers/hub_controller.rb
@@ -31,4 +31,10 @@ class HubController < ApplicationController
        format.html { render :inline => @contents.html_safe , :layout=>'application'  }
     end   
   end
+  
+  def dashboard
+     @categories = Category.all
+     @documents = Document.all
+     @users = User.all
+  end
 end

--- a/app/models/permission.rb
+++ b/app/models/permission.rb
@@ -1,7 +1,7 @@
 class Permission < Struct.new(:user)
   def allow?(controller, action)
     return true if controller == "sessions"
-    return true if controller == "hub" && action.in?(%w[index show])
+    return true if controller == "hub" && action.in?(%w[index])
     return true if controller == "users" && action != "index"
     return true if controller == "categories" && action.in?(%w[index show])
     return true if controller == "documents" && action.in?(%w[index show])

--- a/app/views/hub/dashboard.html.erb
+++ b/app/views/hub/dashboard.html.erb
@@ -1,0 +1,114 @@
+<div class="container">
+
+	<center><h1 style="margin-top:25px; padding:30px; font-size:3.00em; color:#000000 !important;" class="">  Admin Panel </h1></center>
+</div>
+
+<p id="notice"><%= notice %></p>
+
+
+
+
+<div class="col-md-6 well">
+	<div class="container">
+		<h1 class="pull-left">Categories</h1> <%= link_to 'Add New', new_category_path, :class=> "btn btn-default pull-center", :style=>"margin: 30px;" %>
+	</div>	
+	<br>
+	<table class="table-bordered table-striped table-responsive">
+	  <thead>
+	    <tr>
+	      <th>Title</th>
+	      <th>Desc</th>
+	      <th colspan="3"></th>
+	    </tr>
+	  </thead>
+
+	  <tbody>
+	    <% @categories.each do |category| %>
+	      <tr>
+	        <td><%= category.title %></td>
+	        <td><%= category.desc %></td>
+	        <td><%= link_to 'Show', category %></td>
+	        <td><%= link_to 'Edit', edit_category_path(category) %></td>
+	        <td><%= link_to 'Destroy', category, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+	      </tr>
+	    <% end %>
+	  </tbody>
+	</table>
+ 
+<br>
+ 
+</div>
+ 
+<div class="col-xs-1">
+</div>
+
+<div class="col-md-5 well">
+	<div class="container">
+		<h1 class="pull-left">Users</h1>
+	</div>	
+
+	<table  class="table-bordered table-striped table-responsive">
+	  <thead>
+	    <tr>
+	      <th>Email</th>
+	      <th colspan="3"></th>
+	    </tr>
+	  </thead>
+
+	  <tbody>
+	    <% @users.each do |user| %>
+	      <tr>
+	        <td><%= user.email %></td>
+	        <td><%= link_to 'Show', user %></td>
+	        <td><%= link_to 'Edit', edit_user_path(user) %></td>
+	        <td><%= link_to 'Destroy', user, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+	      </tr>
+	    <% end %>
+	  </tbody>
+	</table>
+
+	<br>
+
+	<!--<%= link_to 'New User', new_user_path , :class=> "btn btn-default", :style=>"disabled"%>-->
+
+	</div>
+ 
+
+<div class="col-md-12 well">
+<div class="container">	
+<h1 class="pull-left">Documents</h1>
+
+<%= link_to 'Add New Document', new_document_path, :class=> "btn btn-default pull-center", :style=>"margin:30px;" %>
+</div>
+
+<table  class="table-bordered table-striped table-responsive">
+  <thead>
+    <tr>
+      <th>Name</th>
+      <th>Description</th>
+      <th>Link</th>
+      <th>Category</th>
+      <th colspan="3"></th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% @documents.each do |document| %>
+      <tr>
+        <td><%= document.name %></td>
+        <td><%= document.description %></td>
+        <td><%= document.link %></td>
+        <td><%= document.category %></td>
+        <td><%= link_to 'Show', document %></td>
+        <td><%= link_to 'Edit', edit_document_path(document) %></td>
+        <td><%= link_to 'Destroy', document, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<br>
+
+
+
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,7 +14,7 @@ Rails.application.routes.draw do
   get 'signup', to: 'users#new', as: 'signup'
   get 'login', to: 'sessions#new', as: 'login'
   get 'logout', to: 'sessions#destroy', as: 'logout'
-   
+  get  'dashboard', to: 'hub#dashboard', as: 'dashboard'
 
    
   root 'hub#index', as: 'hub'


### PR DESCRIPTION
Fixes #21. Accessing http://localhost:3000/dashboard will now present a view  to the user which will be a mashup of several operations only permitted for the admin user. The change supported  for the admin user are 1. be able to add new document categories. 2. be able to add new document links under a specific category. 3. be able to modify admin credentials including password reset.  
