### PR TITLE
deploy:Flipping switches to make app work on Heroku

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ gem 'jbuilder', '~> 2.0'
 gem 'sdoc', '~> 0.4.0', group: :doc
 
 gem 'redcarpet'
-
+gem 'rails_12factor'
 gem 'nokogiri'
 gem 'albino'
 gem 'github-markup' 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -117,6 +117,11 @@ GEM
       rails-deprecated_sanitizer (>= 1.0.1)
     rails-html-sanitizer (1.0.3)
       loofah (~> 2.0)
+    rails_12factor (0.0.3)
+      rails_serve_static_assets
+      rails_stdout_logging
+    rails_serve_static_assets (0.0.4)
+    rails_stdout_logging (0.0.4)
     railties (4.2.4)
       actionpack (= 4.2.4)
       activesupport (= 4.2.4)
@@ -181,6 +186,7 @@ DEPENDENCIES
   puma
   pygments.rb (~> 0.6.3)
   rails (= 4.2.4)
+  rails_12factor
   redcarpet
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -29,7 +29,7 @@ Rails.application.configure do
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.
-  config.assets.compile = false
+  config.assets.compile = true
 
   # Asset digests allow you to set far-future HTTP expiration dates on all assets,
   # yet still be able to expire them through the digest params.


### PR DESCRIPTION
Fixes #33. Gemfile needs to have this for heroku. Enable serving assets on Heroku.
