### PR TITLE
content: Move markdown rendering in view files instead of controller

### DIFF
--- a/app/controllers/hub_controller.rb
+++ b/app/controllers/hub_controller.rb
@@ -15,11 +15,13 @@
  #
  
 class HubController < ApplicationController
+  layout 'application'
   
   require 'open-uri'
   def index
      
-    file = open("https://raw.githubusercontent.com/deekoder/doctest/master/README.md").read 
+    @document = Document.first
+    file = open(@document.link).read  
     
     @contents = Redcarpet::Markdown.new(Redcarpet::Render::HTML.new, :tables=>true,:fenced_code_blocks => true,
           :no_intra_emphasis => true,
@@ -27,9 +29,6 @@ class HubController < ApplicationController
           :strikethrough => true,
           :lax_html_blocks => true,
           :superscript => true).render(file)
-    respond_to do |format|
-       format.html { render :inline => @contents.html_safe , :layout=>'application'  }
-    end   
   end
   
   def dashboard

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -16,36 +16,6 @@
  
 module ApplicationHelper
   
-  class CodeRayify < Redcarpet::Render::HTML
-      def block_code(code, language)
-          CodeRay.scan(code, language).div
-      end
-  end 
-  def smarkdown(text)
-      coderayified = CodeRayify.new(filter_html: true,  hard_wrap: true)
-      options = {
-          :fenced_code_blocks => true,
-          :no_intra_emphasis => true,
-          :autolink => true,
-          :strikethrough => true,
-          :lax_html_blocks => true,
-          :superscript => true
-      }
-      markdown_to_html = Redcarpet::Markdown.new(coderayified, options)
-      markdown_to_html.render(text).html_safe
-  end 
-   
- def markdown(text)
-       options = [:hard_wrap, :filter_html, :autolink, :no_intraemphasis, :fenced_code, :tables ]
-       syntax_highlighter(Redcarpet.new(text, *options).to_html).html_safe
- end
-  
- def syntax_highlighter(html)
-    doc = Nokogiri::HTML(html)
-    doc.search("//pre[@lang]").each do |pre|
-      pre.replace Albino.colorize(pre.text.rstrip, pre[:lang])
-    end
-    doc.to_s
- end
+ 
   
 end

--- a/app/views/hub/index.html.erb
+++ b/app/views/hub/index.html.erb
@@ -1,1 +1,4 @@
-  <%= markdown @contents %>
+<%= @contents.html_safe %>
+	
+ 
+


### PR DESCRIPTION
Let's remove rendering html inline from the controller and move the rendering into the index view. This is needed to build other features on top of the content such as edit files. We also no longer need to add syntax highlighting in the application_helper since we have decided to go with a JS solution called Prism.js.
