### PR TITLE
slugs: Use page names as slugs 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,7 @@ gem 'coderay'
 gem 'bcrypt-ruby'
 gem 'toastr-rails'
 gem 'puma'
+gem 'friendly_id'
 
 
 # Use ActiveModel has_secure_password

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,6 +58,8 @@ GEM
     debug_inspector (0.0.2)
     erubis (2.7.0)
     execjs (2.7.0)
+    friendly_id (5.1.0)
+      activerecord (>= 4.0.0)
     github-markup (1.4.0)
     globalid (0.3.6)
       activesupport (>= 4.1.0)
@@ -177,6 +179,7 @@ DEPENDENCIES
   byebug
   coderay
   coffee-rails (~> 4.1.0)
+  friendly_id
   github-markup
   jbuilder (~> 2.0)
   jquery-rails

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -28,7 +28,7 @@ class DocumentsController < ApplicationController
   # GET /documents/1
   # GET /documents/1.json
   def show
-    @document = Document.find(params[:id])
+    @document = Document.friendly.find(params[:id])
     file = open(@document.link).read 
     @contents = Redcarpet::Markdown.new(Redcarpet::Render::HTML.new, :tables=>true,:fenced_code_blocks => true,
           :no_intra_emphasis => true,
@@ -93,7 +93,7 @@ class DocumentsController < ApplicationController
   private
     # Use callbacks to share common setup or constraints between actions.
     def set_document
-      @document = Document.find(params[:id])
+      @document = Document.friendly.find(params[:id])
     end
 
     # Never trust parameters from the scary internet, only allow the white list through.

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -16,4 +16,6 @@
  
 class Document < ActiveRecord::Base
   belongs_to :category
+  extend FriendlyId
+  friendly_id :name, use: :slugged
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -65,7 +65,7 @@
                 <% if category.documents.any? %>
                     <ul>
                       <% category.documents.each do |doc| %>
-                          <li><%= link_to doc.name, document_path(doc.id) %></li>
+                          <li><%= link_to doc.name, document_path(doc.slug) %></li>
                       <% end %>
                     </ul>
                 <% end %>

--- a/db/migrate/20160706220851_add_slug_to_documents.rb
+++ b/db/migrate/20160706220851_add_slug_to_documents.rb
@@ -1,0 +1,6 @@
+class AddSlugToDocuments < ActiveRecord::Migration
+  def change
+    add_column :documents, :slug, :string
+    add_index :documents, :slug
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160630031617) do
+ActiveRecord::Schema.define(version: 20160706220851) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -44,6 +44,7 @@ ActiveRecord::Schema.define(version: 20160630031617) do
     t.integer  "category_id"
     t.datetime "created_at",  null: false
     t.datetime "updated_at",  null: false
+    t.string   "slug"
   end
 
   add_index "documents", ["category_id", "created_at"], name: "index_documents_on_category_id_and_created_at", using: :btree


### PR DESCRIPTION
Fixes #27. We generate slug names with the name of the document and use them while accessing individual documents instead of document ids. This is a must have change to create documents that are SEO ready.
