### PR TITLE
footer: Drive footer text from Brand 

### DIFF
--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -21,6 +21,11 @@
         <% end %>
     <% end %>
   </div>
-
-  Doctor is licensed under Creative Commons Attribution 4.0 International License.
+	<% if @mybrand %>
+			<%=  @mybrand.footer_text %>
+			 
+	<% else %>
+		 	Doctor is licensed under Apache 2.0 License.
+	<% end %>
+  
 </footer>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -10,10 +10,15 @@
 Document.delete_all
 Category.delete_all
 User.delete_all
+Brand.delete_all
 
 if User.count == 0
   User.new({:email =>'sysadmin@minio.io', :password => 'Doctor!23', :password_confirmation => 'Doctor!23', :admin => true }).save
   
+end
+
+if Brand.count == 0
+  Brand.new({:title => 'Doctor', :footer_text => 'Doctor Project is licensed under Apache 2.0 License.'}).save
 end
 
 c1 = Category.create!(title:'Minio Server',


### PR DESCRIPTION
Instead of hardcoding the footer text, modify it to read it from the brand model/object. This makes the footer text to be customizable for those that need to use Doctor Platform.
