### PR TITLE
suggestedits: This is a feature that allows user to send edits.

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -36,9 +36,13 @@ class DocumentsController < ApplicationController
           :strikethrough => true,
           :lax_html_blocks => true,
           :superscript => true).render(file)
-    respond_to do |format|
-       format.html { render :inline => @contents.html_safe , :layout=>'application'  }
-    end  
+          
+          
+    # prepare the suggested edit URL from the document.link      
+    @gitlink = @document.link.dup
+    @gitlink = @gitlink.gsub("raw.githubusercontent","github")
+    @gitlink = @gitlink.sub('master', 'blob/master') 
+     
   end
 
   # GET /documents/new

--- a/app/controllers/hub_controller.rb
+++ b/app/controllers/hub_controller.rb
@@ -29,6 +29,12 @@ class HubController < ApplicationController
           :strikethrough => true,
           :lax_html_blocks => true,
           :superscript => true).render(file)
+    
+    # prepare the suggested edit URL from the document.link          
+    @gitlink = @document.link.dup
+    @gitlink = @gitlink.sub('raw.githubusercontent','github')
+    @gitlink = @gitlink.sub('master', 'blob/master') 
+            
   end
   
   def dashboard

--- a/app/views/documents/show.html.erb
+++ b/app/views/documents/show.html.erb
@@ -1,24 +1,8 @@
-<p id="notice"><%= notice %></p>
 
-<p>
-  <strong>Name:</strong>
-  <%= @document.name %>
-</p>
+ <!-- Needs to be Styled. Please put styling params in :class-->
 
-<p>
-  <strong>Description:</strong>
-  <%= @document.description %>
-</p>
-
-<p>
-  <strong>Link:</strong>
-  <%= @document.link %>
-</p>
-
-<p>
-  <strong>Category:</strong>
-  <%= @document.category %>
-</p>
-
-<%= link_to 'Edit', edit_document_path(@document) %> |
-<%= link_to 'Back', documents_path %>
+ <%= link_to 'suggest edits', @gitlink, :class=> "btn btn-primary" %>
+	 	 
+ <%= @contents.html_safe %>
+	 
+ 

--- a/app/views/hub/index.html.erb
+++ b/app/views/hub/index.html.erb
@@ -1,4 +1,9 @@
-<%= @contents.html_safe %>
-	
+
+ <!-- Needs to be styled. Please put styling params in :class -->
  
+ <%= link_to 'suggest edits', gitlink, :class=> "btn btn-primary" %>
+	 	 
+ <%= @contents.html_safe %>
+	 
+
 


### PR DESCRIPTION
Fixes #15. We generate the edit URL on the fly and allow for the user to click on and go to github page to send a PR for their suggested edits. This fix however will have a second styling fix from Rushan that will instruct the user how to send a PR using a popover widget.
