### PR TITLE
page access: Do not allow non admins to edit categories and documents.

### DIFF
--- a/app/models/permission.rb
+++ b/app/models/permission.rb
@@ -3,8 +3,8 @@ class Permission < Struct.new(:user)
     return true if controller == "sessions"
     return true if controller == "hub" && action.in?(%w[index])
     return true if controller == "users" && action != "index"
-    return true if controller == "categories" && action.in?(%w[index show])
-    return true if controller == "documents" && action.in?(%w[index show])
+    #return true if controller == "categories" && action.in?(%w[show])
+    return true if controller == "documents" && action.in?(%w[show])
   
     if user
       return true if controller == "categories" && action.in?(%w[index show edit new create])


### PR DESCRIPTION
Right now users are able to access dashboard pages that only admins can access. With this fix, non admins will no longer be able to access these pages. Fixes #83
