### PR TITLE
404pages: Allow errors to show even for non logged in users.

### DIFF
--- a/app/models/permission.rb
+++ b/app/models/permission.rb
@@ -5,6 +5,8 @@ class Permission < Struct.new(:user)
     return true if controller == "users" && action != "index"
     #return true if controller == "categories" && action.in?(%w[show])
     return true if controller == "documents" && action.in?(%w[show])
+    return true if controller == "errors"
+    
   
     if user
       return true if controller == "categories" && action.in?(%w[index show edit new create])


### PR DESCRIPTION
This is missed in the previous checkin. Whenever we add new controllers we have to ask ourselves about permission levels. By default the doctor design uses auth wall for everything unless you whitelist it deliberately. By this design - added error controller to return true for all not just logged in admin users.
