### PR TITLE
doc: Remove --path vendor/bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 ```
 > git clone https://github.com/minio/doctor.git
 > cd doctor
-> bundle install --path vendor/bundle
+> bundle install
 > rake db:drop
 > rake db:setup
 > rails s


### PR DESCRIPTION
Fails on Mac OS very often. Just use bundle install is sufficient for all OSs.
