### PR TITLE
docs category: Display the category already selected.

### DIFF
--- a/app/views/documents/_form.html.erb
+++ b/app/views/documents/_form.html.erb
@@ -29,8 +29,14 @@
 
       <div class="form-group">
         <%= f.label :category_id %>
-		    <%= f.select :category_id, options_for_select(@categories.map{|s|[s.title, s.id]}), :class => 'form-group__field' %>
-
+			
+			<% if @document.new_record? %> 
+				<%= f.select :category_id, options_from_collection_for_select(@categories,"id", "title")  %>
+			<% else %>	
+		 		<%= f.select :category_id, options_from_collection_for_select(@categories,"id", "title", @document.category.id)  %>
+	 
+			<% end %>	
+		  	    
       </div>
 
       <div class="form-wrapper__footer">


### PR DESCRIPTION
This fixes #127. Swapped options_for_select to options_from_collection_for_select because setting selected value in rails is very  cumbersome in option_for_select method.  Finally since this partial is used by both new and edit actions, we have to do conditional handling. In the new action, the document category is nil. 
