### PR TITLE
analytics: Add mixpanel analytics support for Doctor.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,7 @@ gem 'toastr-rails'
 gem 'puma'
 gem 'friendly_id'
 gem 'font-awesome-sass', '~> 4.6.2'
-
+gem 'mengpaneel'
 
 # Use ActiveModel has_secure_password
 # gem 'bcrypt', '~> 3.1.7'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,12 +76,16 @@ GEM
       nokogiri (>= 1.5.9)
     mail (2.6.4)
       mime-types (>= 1.16, < 4)
+    mengpaneel (0.0.2)
+      activesupport
+      mixpanel-ruby
     method_source (0.8.2)
     mime-types (3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
     mini_portile2 (2.1.0)
     minitest (5.9.0)
+    mixpanel-ruby (2.2.0)
     multi_json (1.12.1)
     nokogiri (1.6.8)
       mini_portile2 (~> 2.1.0)
@@ -184,6 +188,7 @@ DEPENDENCIES
   github-markup
   jbuilder (~> 2.0)
   jquery-rails
+  mengpaneel
   nokogiri
   pg
   pry

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -28,7 +28,8 @@ class ApplicationController < ActionController::Base
 
   delegate :allow?, to: :current_permission
   helper_method :allow?
-
+  include Mengpaneel::Controller
+  before_action :setup_mixpanel
 
   private
   
@@ -57,4 +58,22 @@ class ApplicationController < ActionController::Base
     @documents = Document.where(:category_id => params[:id])
     @mybrand = Brand.first 
   end
+  
+  def setup_mixpanel
+    return unless current_user
+
+    # For technical reasons, you need to do setup from a `mengpaneel.setup` block.
+    # I'll go into those reasons later.
+    mengpaneel.setup do
+      mixpanel.identify(current_user.id)
+
+      mixpanel.people.set(
+        "ID"              => current_user.id,
+        "$email"          => current_user.email,
+        "$created"        => current_user.created_at
+         
+      )
+    end
+  end
+  
 end

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -37,7 +37,7 @@ class DocumentsController < ApplicationController
           :lax_html_blocks => true,
           :superscript => true).render(file)
           
-          
+    mixpanel.track("Doc Page Viewed", "Page Title" => @document.name )        
     # prepare the suggested edit URL from the document.link      
     @gitlink = @document.link.dup
     @gitlink = @gitlink.gsub("raw.githubusercontent","github")

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -1,9 +1,11 @@
 class ErrorsController < ApplicationController
   def not_found
+    mixpanel.track("404 Not Found")  
     render(:status => 404)
   end
 
   def internal_server_error
+    mixpanel.track("Internal Server Error")  
     render(:status => 500)
   end
 end

--- a/app/controllers/hub_controller.rb
+++ b/app/controllers/hub_controller.rb
@@ -29,7 +29,8 @@ class HubController < ApplicationController
           :strikethrough => true,
           :lax_html_blocks => true,
           :superscript => true).render(file)
-    
+      
+    mixpanel.track("Home Page Viewed")  
     # prepare the suggested edit URL from the document.link          
     @gitlink = @document.link.dup
     @gitlink = @gitlink.sub('raw.githubusercontent','github')
@@ -48,6 +49,7 @@ class HubController < ApplicationController
      @user_count = User.count
      
      @brands = Brand.all
+     mixpanel.track("DashBoard Viewed")  
   end
   
   private

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -26,6 +26,9 @@ class SessionsController < ApplicationController
     if user && user.authenticate(params[:password])
       session[:user_id] = user.id
        if current_user.admin
+         mixpanel.track("Sign In", "ID"          => current_user.id,
+                                    "Email"       => current_user.email) 
+                                    
         redirect_to dashboard_path, info: "Welcome back admin!"
        else 
         redirect_to hub_index, warning: "Not Authorized!"
@@ -38,6 +41,7 @@ class SessionsController < ApplicationController
 
   def destroy
     session[:user_id] = nil
+    mixpanel.track("Sign Out")
     redirect_to hub_url, notice: "Logged out!"
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -45,6 +45,7 @@ class UsersController < ApplicationController
     @user.admin = false
     respond_to do |format|
       if @user.save
+        mixpanel.track("User Created",  "Email" => params[:email])
         format.html { redirect_to @user, notice: 'User was successfully created.' }
         format.json { render :show, status: :created, location: @user }
       else
@@ -59,6 +60,7 @@ class UsersController < ApplicationController
   def update
     respond_to do |format|
       if @user.update(user_params)
+        mixpanel.track("User Info Updated")
         format.html { redirect_to @user, notice: 'User was successfully updated.' }
         format.json { render :show, status: :ok, location: @user }
       else
@@ -73,6 +75,7 @@ class UsersController < ApplicationController
   def destroy
     @user.destroy
     respond_to do |format|
+      mixpanel.track("User Deleted ")
       format.html { redirect_to users_url, notice: 'User was successfully destroyed.' }
       format.json { head :no_content }
     end

--- a/config/initializers/mengpaneel.rb
+++ b/config/initializers/mengpaneel.rb
@@ -1,0 +1,3 @@
+Mengpaneel.configure do |config|
+  config.token =  ENV["MIXPANEL_TOKEN"]  
+end


### PR DESCRIPTION
 This adds generic support for MixPanel in the Doctor Framework. Users can add their own tokens by setting ENV[MIXPANEL_TOKEN] when doctor server is started. Fixes issue #156 
