### PR TITLE
Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM ruby:2.2.2
+RUN apt-get update -qq && apt-get install -y build-essential libpq-dev nodejs
+RUN mkdir /doctor
+WORKDIR /doctor
+ADD Gemfile Gemfile.lock /doctor/
+RUN bundle install
+ADD . /doctor
+RUN rm config/database.yml
+# TODO: ADD console_whitelist.rb config/initializers/

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# Project Doctor 
-* Doctor is a Documentation Server for all your project docs. 
+# Project Doctor
+* Doctor is a Documentation Server for all your project docs.
 * Doctor beautifully decouples document serving and document contents.
 * Create your docs in markdown. Store them anywhere (github/dropbox/google drive/ anywhere really).
-* Login to Doctor's Dashboard. Setup links to your doc files in Doctor's Dashboard. 
-* You are done! 
+* Login to Doctor's Dashboard. Setup links to your doc files in Doctor's Dashboard.
+* You are done!
 
 
 ## Pre-Requisites to Deploy Doctor
@@ -28,16 +28,21 @@
 > rake db:setup
 > rails s
 ```
-Now visit http://localhost:3000 
+Now visit http://localhost:3000
 
 Use `sysadmin@doctor.io` with password `Doctor!23` to login. Visit [http://localhost:3000](http://localhost:3000) to navigate the docs. This can be changed anytime via the Dashboard. We highly recommend that you do if you use Doctor in deployment.
 
+### Using Docker
+```bash
+> git clone https://github.com/minio/doctor.git
+> cd doctor
+> docker-compose up
+```
+
 ## Organization
-* Documents are organized under Categories. 
+* Documents are organized under Categories.
 * Login to the dashboard
 * Step 1 : Use the Dashboard to create a new Category : http://localhost:3000/category/new
 * Step 2 : Use the Dashboard to create a link to a new Document : http://localhost:3000/document/new
 * Step 3: Paste the raw URL to the md file when linking a new document. The "Raw" button is on the top of the MD file in github.
 * Required : All documents need to be associated under a Category
-
-

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+version: '2'
+services:
+  db:
+    image: postgres
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+  web:
+    build: .
+# FIXME: don't destroy data between restarts
+# FIXME: wait for postgres to get ready on the first run
+    command: bash -c "bundle exec rake db:setup && bundle exec rails s -p 3000 -b '0.0.0.0'"
+    environment:
+      DATABASE_URL: postgresql://postgres:postgres@db/doctor?pool=5
+    ports:
+      - "3000:3000"
+    depends_on:
+      - db


### PR DESCRIPTION
Fixes #93 

This allows you to build a Docker image that can then be uploaded to Docker Hub.  It also has a docker-compose.yml file that lets you run Doctor by running `docker-compose up`.  I updated the documentation to include this feature.

Needs work:
- Keep data between docker-compose restarts (the web command always runs the database setup, thus destroying any data)
- Make sure postgres is up before trying to connect (on the first run of the postgres docker image it takes a bit longer to get ready as it needs to set itself up)
