### PR TITLE
bugfixes: move pry & fix #176

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,6 @@ gem 'nokogiri'
 gem 'albino'
 gem 'github-markup' 
 gem 'pygments.rb', '~> 0.6.3'
-gem 'pry'
 gem 'pg'
 gem 'coderay'
 gem 'bcrypt'
@@ -51,6 +50,7 @@ gem 'mengpaneel'
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug'
+  gem 'pry'
 end
 
 group :development do

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -60,8 +60,7 @@ class CategoriesController < ApplicationController
   def update
     respond_to do |format|
       if @category.update(category_params)
-        format.html { redirect_to @category, notice: 'Category was successfully updated.' }
-        format.json { render :show, status: :ok, location: @category }
+        format.html { render :edit , notice: 'Category was successfully updated.'}
       else
         format.html { render :edit }
         format.json { render json: @category.errors, status: :unprocessable_entity }

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -75,8 +75,7 @@ class DocumentsController < ApplicationController
   def update
     respond_to do |format|
       if @document.update(document_params)
-        format.html { redirect_to @document, notice: 'Document was successfully updated.' }
-        format.json { render :show, status: :ok, location: @document }
+         format.html { render :edit,  notice: 'Document was successfully created.' }
       else
         format.html { render :edit }
         format.json { render json: @document.errors, status: :unprocessable_entity }


### PR DESCRIPTION
Move gem pry to be used only in dev & test groups. Do not redirect after saving docs and categories so that users don't have to go back to edit again and again.
