### PR TITLE
fix images urls when relative paths are used in markdown

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -30,7 +30,9 @@ class DocumentsController < ApplicationController
   def show
     @document = Document.friendly.find(params[:id])
     file = open(@document.link).read 
-    @contents = Redcarpet::Markdown.new(Redcarpet::Render::HTML.new, :tables=>true,:fenced_code_blocks => true,
+    @renderer = Render.new;
+    @renderer.setDocument(@document);
+    @contents = Redcarpet::Markdown.new(@renderer, :tables=>true,:fenced_code_blocks => true,
           :no_intra_emphasis => true,
           :autolink => true,
           :strikethrough => true,

--- a/app/models/render.rb
+++ b/app/models/render.rb
@@ -1,0 +1,13 @@
+class Render < Redcarpet::Render::HTML
+  def setDocument(document)
+     @document = document
+  end
+  def image(link, title, alt_text)
+    if not link.start_with?("http", "https")
+      splittedLink = @document.link.split("/")
+      link = splittedLink.take(splittedLink.size - 1).join("/") + "/" + link
+    end
+    %(<img src="#{link}" title="#{title}" alt="#{alt_text}" />)
+  end
+end
+


### PR DESCRIPTION
When relative paths where used in markdown, the images where not
displayed.
Now, if the path does not start with http or http, we prefix
the image path with the document link.

fixes #241