### PR TITLE
dashboard: Remove settings that are non essential to users.

### DIFF
--- a/app/views/brands/_form.html.erb
+++ b/app/views/brands/_form.html.erb
@@ -85,40 +85,7 @@
 
             <!-- Appearance -->
             <div class="tab-content__pane" id="appearance">
-                <div class="misc-title">Scaffolding</div>
-                <div class="form-wrapper form-wrapper--stack">
-                    <div class="form-group">
-                        <%= f.label :font_family, 'Font family' %>
-                        <%= f.text_field :font_family, :class => 'form-group__field' %>
-                        <%= icon('question-circle-o form-group__help', :data => {toggle: 'tooltip'}, :title => 'Sets a font family to change the overall look of the texts') %>
-                    </div>
-
-                    <div class="form-group">
-                        <%= f.label :font_size, 'Font size' %>
-						<%= f.select :font_size, [ '11px', '12px', '13px', '14px', '15px', '16px', '17px' ],  :class=>"form-group__field" %>
-                        <%= icon('question-circle-o form-group__help', :data => {toggle: 'tooltip'}, :title => 'Sets the overall font sizes including paragraphs, heading, links, etc.') %>
-                    </div>
-
-                    <div class="form-group">
-                        <%= f.label :text_color, 'Text color' %>
-                        <%= f.text_field :text_color, :class => 'form-group__field form-group__field--color' %>
-                        <%= icon('question-circle-o form-group__help', :data => {toggle: 'tooltip'}, :title => 'Sets a custom text color for documents') %>
-                    </div>
-
-                    <div class="form-group">
-                        <%= f.label :link_color, 'Link color' %>
-                        <%= f.text_field :link_color, :class => 'form-group__field form-group__field--color' %>
-                        <%= icon('question-circle-o form-group__help', :data => {toggle: 'tooltip'}, :title => 'Sets a custom link color for documents') %>
-
-                    </div>
-
-                    <div class="form-group">
-                        <%= f.label :heading_color, 'Heading color' %>
-                        <%= f.text_field :heading_color, :class => 'form-group__field form-group__field--color' %>
-                        <%= icon('question-circle-o form-group__help', :data => {toggle: 'tooltip'}, :title => 'Sets a custom heading color for documents which includes h1 - h6') %>
-
-                    </div>
-                </div>
+                 
 
                 <div class="misc-title">Header</div>
                 <div class="form-wrapper form-wrapper--stack">
@@ -134,34 +101,16 @@
                         <%= icon('question-circle-o form-group__help', :data => {toggle: 'tooltip'}, :title => 'Sets a background color for site header which will match your brand. Make sure to set a darker background as text and icon will remain white. ') %>
                     </div>
                 </div>
-
-                <div class="misc-title">Sidebar</div>
-                <div class="form-wrapper">
+                
+                <div class="misc-title">Tokens</div>
+                <div class="form-wrapper form-wrapper--stack">
                     <div class="form-group">
-                        <%= f.label :sidebar_background_color, 'Background color' %>
-                        <%= f.text_field :sidebar_background_color, :class => 'form-group__field form-group__field--color' %>
-                        <%= icon('question-circle-o form-group__help', :data => {toggle: 'tooltip'}, :title => 'Sets a custom background color for the left sidebar') %>
-                    </div>
-
-                    <div class="form-group">
-                        <%= f.label :sidebar_link_color, 'Link color' %>
-                        <%= f.text_field :sidebar_link_color, :class => 'form-group__field form-group__field--color' %>
-                        <%= icon('question-circle-o form-group__help', :data => {toggle: 'tooltip'}, :title => 'Sets a custom text color for sidebar menu links') %>
-                    </div>
-
-                    <div class="form-group">
-                        <%= f.label :menu_hover_background_color, 'Menu link hover background color' %>
-                        <%= f.text_field :menu_hover_background_color, :class => 'form-group__field form-group__field--color' %>
-                        <%= icon('question-circle-o form-group__help', :data => {toggle: 'tooltip'}, :title => 'Sets a background color to toggle when mouse-hover the menu links') %>
-                    </div>
-
-                    <div class="form-group">
-                        <%= f.label :menu_title_color, 'Menu title color' %>
-                        <%= f.text_field :menu_title_color, :class => 'form-group__field form-group__field--color' %>
-                        <%= icon('question-circle-o form-group__help', :data => {toggle: 'tooltip'}, :title => 'Sets a custom text color for menu link titles') %>
-
+                        <%= f.label :searchtoken, 'Algolia Document Search Token' %>
+                        <%= f.text_field :searchtoken, :class => 'form-group__field  ' %>
+                        <%= icon('question-circle-o form-group__help', :data => {toggle: 'tooltip'}, :title => 'Sets algolia search token that is used for document search.') %>
                     </div>
                 </div>
+ 
             </div>
 
             <div class="form-footer">

--- a/db/migrate/20170214194932_add_searchtoken_to_brands.rb
+++ b/db/migrate/20170214194932_add_searchtoken_to_brands.rb
@@ -1,0 +1,5 @@
+class AddSearchtokenToBrands < ActiveRecord::Migration
+  def change
+    add_column :brands, :searchtoken, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161207002743) do
+ActiveRecord::Schema.define(version: 20170214194932) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -43,6 +43,7 @@ ActiveRecord::Schema.define(version: 20161207002743) do
     t.string   "slack_link"
     t.string   "description"
     t.string   "bitbucket_link"
+    t.string   "searchtoken"
   end
 
   create_table "categories", force: :cascade do |t|


### PR DESCRIPTION
Add algolia search token as doctor's default search. Users can now set a token and take advantage of https://community.algolia.com/docsearch/ to enable search on their documentation.