### PR TITLE
config: Removed exposing unnecessary routes.

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,7 +19,6 @@ Rails.application.routes.draw do
   get 'docs/:id/unhide', to: 'documents#unhide', as: 'unhide'
   resources :sessions
   resources :categories
-  get 'hub/index'
 
   get 'login', to: 'sessions#new', as: 'login'
   get 'logout', to: 'sessions#destroy', as: 'logout'


### PR DESCRIPTION
Disables hub/index to be accessible in the doctor app. Fixes #347 