### PR TITLE
ssl: Don't force https in development or test situations.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -34,7 +34,7 @@ class ApplicationController < ActionController::Base
     private
 
     def redirect_https
-        redirect_to :protocol => "https://" unless (request.ssl? || request.local?)
+        redirect_to :protocol => "https://" unless (request.ssl?  || request.local? || Rails.env.development? || Rails.env.test?)
         return true
     end
     before_filter :redirect_https


### PR DESCRIPTION
Fixes #353 and also address this issue in general.

- If doctor is started locally -> no SSL
- If doctor is started with RAILS_ENV=development -> no ssl
- If doctor is started with RAILS_ENV=test -> no ssl
- If doctor is started with RAILS_ENV=production -> always use ssl